### PR TITLE
Feat/typeorm entities

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "Equipment Management Backend",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node-dev --respawn src/index.ts"
+  },
+  "dependencies": {
+    "typeorm": "^0.3.20",
+    "reflect-metadata": "^0.2.1",
+    "pg": "^8.11.3",
+    "dotenv": "^16.3.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "ts-node-dev": "^2.0.0",
+    "@types/node": "^20.10.0"
+  }
+}

--- a/backend/src/entities/activity-log.entity.ts
+++ b/backend/src/entities/activity-log.entity.ts
@@ -1,0 +1,35 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, CreateDateColumn } from 'typeorm';
+import { User } from './user.entity';
+
+@Entity('activity_logs')
+export class ActivityLog {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ length: 50 })
+  action: string;
+
+  @Column({ length: 100 })
+  entity_type: string;
+
+  @Column()
+  entity_id: number;
+
+  @Column({ type: 'json', nullable: true })
+  changes: object;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @Column({ nullable: true })
+  ip_address: string;
+
+  @Column()
+  user_id: number;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @ManyToOne(() => User)
+  user: User;
+}

--- a/backend/src/entities/alert.entity.ts
+++ b/backend/src/entities/alert.entity.ts
@@ -1,0 +1,32 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, CreateDateColumn } from 'typeorm';
+import { Equipment } from './equipment.entity';
+
+@Entity('alerts')
+export class Alert {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ length: 100 })
+  title: string;
+
+  @Column({ type: 'text' })
+  message: string;
+
+  @Column({ default: 'info' })
+  severity: string;
+
+  @Column({ default: 'unread' })
+  status: string;
+
+  @Column({ nullable: true })
+  triggered_by: string;
+
+  @Column()
+  equipment_id: number;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @ManyToOne(() => Equipment)
+  equipment: Equipment;
+}

--- a/backend/src/entities/category.entity.ts
+++ b/backend/src/entities/category.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity('categories')
+export class Category {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true, length: 100 })
+  name: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @Column({ default: true })
+  is_active: boolean;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+}

--- a/backend/src/entities/checkout.entity.ts
+++ b/backend/src/entities/checkout.entity.ts
@@ -1,0 +1,45 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { User } from './user.entity';
+import { Equipment } from './equipment.entity';
+
+@Entity('checkouts')
+export class Checkout {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  checkout_date: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  expected_return_date: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  actual_return_date: Date;
+
+  @Column({ type: 'text', nullable: true })
+  purpose: string;
+
+  @Column({ default: 'pending' })
+  status: string;
+
+  @Column({ type: 'text', nullable: true })
+  notes: string;
+
+  @Column()
+  user_id: number;
+
+  @Column()
+  equipment_id: number;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+
+  @ManyToOne(() => User)
+  user: User;
+
+  @ManyToOne(() => Equipment)
+  equipment: Equipment;
+}

--- a/backend/src/entities/equipment.entity.ts
+++ b/backend/src/entities/equipment.entity.ts
@@ -1,0 +1,47 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { Category } from './category.entity';
+
+@Entity('equipment')
+export class Equipment {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ length: 100 })
+  name: string;
+
+  @Column({ unique: true, length: 50 })
+  asset_tag: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @Column({ nullable: true })
+  serial_number: string;
+
+  @Column({ default: 'available' })
+  status: string;
+
+  @Column({ type: 'decimal', precision: 10, scale: 2, nullable: true })
+  purchase_price: number;
+
+  @Column({ type: 'date', nullable: true })
+  purchase_date: Date;
+
+  @Column({ nullable: true })
+  location: string;
+
+  @Column({ default: true })
+  is_active: boolean;
+
+  @Column()
+  category_id: number;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+
+  @ManyToOne(() => Category)
+  category: Category;
+}

--- a/backend/src/entities/maintenance.entity.ts
+++ b/backend/src/entities/maintenance.entity.ts
@@ -1,0 +1,48 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { User } from './user.entity';
+import { Equipment } from './equipment.entity';
+
+@Entity('maintenance')
+export class Maintenance {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ length: 100 })
+  title: string;
+
+  @Column({ type: 'text' })
+  description: string;
+
+  @Column({ default: 'scheduled' })
+  status: string;
+
+  @Column({ type: 'timestamp' })
+  scheduled_date: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  completed_date: Date;
+
+  @Column({ type: 'decimal', precision: 10, scale: 2, nullable: true })
+  cost: number;
+
+  @Column({ type: 'text', nullable: true })
+  technician_notes: string;
+
+  @Column()
+  equipment_id: number;
+
+  @Column({ nullable: true })
+  assigned_to: number;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+
+  @ManyToOne(() => Equipment)
+  equipment: Equipment;
+
+  @ManyToOne(() => User)
+  assigned_to_user: User;
+}

--- a/backend/src/entities/user.entity.ts
+++ b/backend/src/entities/user.entity.ts
@@ -1,0 +1,34 @@
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity('users')
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true, length: 50 })
+  username: string;
+
+  @Column({ unique: true })
+  email: string;
+
+  @Column()
+  password_hash: string;
+
+  @Column({ default: 'user' })
+  role: string;
+
+  @Column({ nullable: true })
+  full_name: string;
+
+  @Column({ nullable: true })
+  phone: string;
+
+  @Column({ default: true })
+  is_active: boolean;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": false,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
TypeORM entities created and TypeScript-verified. Ready for backend API development. Unblocks API layer.

✅ Added 7 entity files:
- user.entity.ts
- category.entity.ts
- equipment.entity.ts
- checkout.entity.ts
- maintenance.entity.ts
- alert.entity.ts
- activity-log.entity.ts

✅ Configured tsconfig.json for TypeORM decorators
✅ Verified with `npx tsc --noEmit` (zero errors)